### PR TITLE
Update post schedule and content variety

### DIFF
--- a/packages/linkedin/posts/2025-06-09-dynamic-vs-static-rehab.md
+++ b/packages/linkedin/posts/2025-06-09-dynamic-vs-static-rehab.md
@@ -1,6 +1,6 @@
 ---
 title: "Dynamic vs Static Rehab: Why Early Range Matters"
-date: 2025-07-01
+date: 2025-06-09
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-06-10-andrew-lawrence-splint-review.md
+++ b/packages/linkedin/posts/2025-06-10-andrew-lawrence-splint-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Athlete Spotlight 🎯 Andrew Lawrence on Night Splints"
-date: 2025-07-16
+date: 2025-06-10
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-06-12-carbon-footprint-splint.md
+++ b/packages/linkedin/posts/2025-06-12-carbon-footprint-splint.md
@@ -1,6 +1,6 @@
 ---
 title: "Shrinking Footprints 🌍 One Splint at a Time"
-date: 2025-07-05
+date: 2025-06-12
 type: "Founder"
 ---
 

--- a/packages/linkedin/posts/2025-06-13-week4-calf-raises.md
+++ b/packages/linkedin/posts/2025-06-13-week4-calf-raises.md
@@ -1,6 +1,6 @@
 ---
 title: "Week-4 Milestone: The Power of Calf Raises"
-date: 2025-07-27
+date: 2025-06-13
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-06-16-heel-lift-tendon-strain.md
+++ b/packages/linkedin/posts/2025-06-16-heel-lift-tendon-strain.md
@@ -1,6 +1,6 @@
 ---
 title: "A $20 Heel Lift That Halves Tendon Strain"
-date: 2025-07-02
+date: 2025-06-16
 type: "Product"
 ---
 

--- a/packages/linkedin/posts/2025-06-17-olivia-blatch-splint-review.md
+++ b/packages/linkedin/posts/2025-06-17-olivia-blatch-splint-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Weightlifter Wisdom 🚀 Olivia Blatch on Staying Splint-Safe"
-date: 2025-07-17
+date: 2025-06-17
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-06-19-patient-safety-dataset.md
+++ b/packages/linkedin/posts/2025-06-19-patient-safety-dataset.md
@@ -1,6 +1,6 @@
 ---
 title: "Why Surgeons Trust Our 3,000-Patient Safety Dataset"
-date: 2025-07-24
+date: 2025-06-19
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-06-20-holiday-travel-kit.md
+++ b/packages/linkedin/posts/2025-06-20-holiday-travel-kit.md
@@ -1,6 +1,6 @@
 ---
 title: "Holiday Travel Kit ✈️ Guidance for Your Achilles Patients"
-date: 2025-07-30
+date: 2025-06-20
 type: "Product"
 ---
 

--- a/packages/linkedin/posts/2025-06-23-45deg-plantarflexion.md
+++ b/packages/linkedin/posts/2025-06-23-45deg-plantarflexion.md
@@ -1,6 +1,6 @@
 ---
 title: "Why 45° Plantarflexion Might Do More Harm Than Good"
-date: 2025-07-11
+date: 2025-06-23
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-06-24-kim-daybell-splint-review.md
+++ b/packages/linkedin/posts/2025-06-24-kim-daybell-splint-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Doctor & Olympian Kim Daybell: Sleep Is Medicine"
-date: 2025-07-18
+date: 2025-06-24
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-06-26-timeline-by-country-launch.md
+++ b/packages/linkedin/posts/2025-06-26-timeline-by-country-launch.md
@@ -1,6 +1,6 @@
 ---
 title: "AchillesRupture.com Goes International (Interactive Timelines)"
-date: 2025-07-26
+date: 2025-06-26
 type: "Product"
 ---
 

--- a/packages/linkedin/posts/2025-06-27-tendon-loading-101.md
+++ b/packages/linkedin/posts/2025-06-27-tendon-loading-101.md
@@ -1,6 +1,6 @@
 ---
 title: "Achilles Tendon Loading 101: Get the Goldilocks Dose"
-date: 2025-07-31
+date: 2025-06-27
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-06-30-boot-vs-splint-sleep.md
+++ b/packages/linkedin/posts/2025-06-30-boot-vs-splint-sleep.md
@@ -1,6 +1,6 @@
 ---
 title: "Boot vs Splint: The Sleep-Off Your Patients Care About"
-date: 2025-07-12
+date: 2025-06-30
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-07-01-steff-evans-splint-review.md
+++ b/packages/linkedin/posts/2025-07-01-steff-evans-splint-review.md
@@ -1,6 +1,6 @@
 ---
 title: "Rugby Comeback 🏉 Steff Evans' Night-Time Game Changer"
-date: 2025-07-19
+date: 2025-07-01
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-07-03-google-search-insights.md
+++ b/packages/linkedin/posts/2025-07-03-google-search-insights.md
@@ -1,6 +1,6 @@
 ---
 title: "What 10K Google Searches Tell Us About Achilles Patients"
-date: 2025-08-01
+date: 2025-07-03
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-07-04-regulatory-cost-showdown.md
+++ b/packages/linkedin/posts/2025-07-04-regulatory-cost-showdown.md
@@ -1,6 +1,6 @@
 ---
 title: "Regulatory Price-Tag Showdown: UKCA vs FDA 510(k)"
-date: 2025-07-14
+date: 2025-07-04
 type: "Founder"
 ---
 

--- a/packages/linkedin/posts/2025-07-07-early-weight-bearing-evidence.md
+++ b/packages/linkedin/posts/2025-07-07-early-weight-bearing-evidence.md
@@ -1,6 +1,6 @@
 ---
 title: "Why Surgeons Love Early Weight-Bearing (The Data)"
-date: 2025-07-22
+date: 2025-07-07
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-07-08-ollie-lawrence-splint-review.md
+++ b/packages/linkedin/posts/2025-07-08-ollie-lawrence-splint-review.md
@@ -1,6 +1,6 @@
 ---
 title: "England Rugby Star Ollie Lawrence: Rehab 'Game Changer'"
-date: 2025-07-20
+date: 2025-07-08
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-07-10-diy-vs-medical-splint.md
+++ b/packages/linkedin/posts/2025-07-10-diy-vs-medical-splint.md
@@ -1,6 +1,6 @@
 ---
 title: "DIY Cast vs Clinical Splint: Mr James Davis Explains the Difference"
-date: 2025-07-15
+date: 2025-07-10
 type: "Story"
 ---
 

--- a/packages/linkedin/posts/2025-07-11-neuroscience-of-pain.md
+++ b/packages/linkedin/posts/2025-07-11-neuroscience-of-pain.md
@@ -1,6 +1,6 @@
 ---
 title: "The Neuroscience of Achilles Pain (or Lack Thereof)"
-date: 2025-07-28
+date: 2025-07-11
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-07-14-4000-splints-milestone.md
+++ b/packages/linkedin/posts/2025-07-14-4000-splints-milestone.md
@@ -1,6 +1,6 @@
 ---
 title: "4,000 Splints Shipped—Milestone Unlocked"
-date: 2025-07-08
+date: 2025-07-14
 type: "Founder"
 ---
 

--- a/packages/linkedin/posts/2025-07-15-liner-care-night-splint.md
+++ b/packages/linkedin/posts/2025-07-15-liner-care-night-splint.md
@@ -1,6 +1,6 @@
 ---
 title: "Night-Splint Care 101: Fresh Liners, Happy Tendons"
-date: 2025-07-25
+date: 2025-07-15
 type: "Product"
 ---
 

--- a/packages/linkedin/posts/2025-07-17-3min-morning-mobility.md
+++ b/packages/linkedin/posts/2025-07-17-3min-morning-mobility.md
@@ -1,6 +1,6 @@
 ---
 title: "3-Minute Morning Mobility for Rupture Patients"
-date: 2025-07-29
+date: 2025-07-17
 type: "Evidence"
 ---
 

--- a/packages/linkedin/posts/2025-07-18-rick-las-patient-story.md
+++ b/packages/linkedin/posts/2025-07-18-rick-las-patient-story.md
@@ -1,6 +1,6 @@
 ---
 title: "From Boot to Rehab: Rick's No-Surgery Success Story"
-date: 2025-07-03
+date: 2025-07-18
 type: "Story"
 ---
 


### PR DESCRIPTION
I modified the content publishing schedule for 24 posts in the `packages/linkedin/posts/` directory.

My goal was to:
*   Reschedule posts originally dated after 2025-06-01.
*   Implement a cadence of four posts per week, specifically on Monday, Tuesday, Thursday, and Friday.
*   Start this new schedule from Monday, June 9, 2025.
*   Ensure content variety across the week, avoiding clustering similar topics (e.g., athlete stories) on the same day.

To achieve this, for each of the 24 affected posts, I:
*   Renamed the markdown file (e.g., `packages/linkedin/posts/2025-07-01-dynamic-vs-static-rehab.md` became `packages/linkedin/posts/2025-06-09-dynamic-vs-static-rehab.md`).
*   Updated the `date` field in the frontmatter of each file to match the new publication date (e.g., `date: 2025-07-01` became `date: 2025-06-09`).

This re-organization covers a six-week period, from June 9, 2025, to July 18, 2025, and ensures a balanced distribution of "Athlete Stories," "Evidence," "Product," and "Founder" content types throughout the weeks.