### PR TITLE
Edit order items and their changes

### DIFF
--- a/apps/ship-stock/src/components/Combobox.tsx
+++ b/apps/ship-stock/src/components/Combobox.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@thetis/ui/form";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@thetis/ui/popover";
+import { Button } from "@thetis/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@thetis/ui/command";
+import { cn } from "@/lib/utils";
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  name: string;
+  label?: string;
+  options: ComboboxOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const Combobox = ({
+  name,
+  label,
+  options,
+  placeholder = "Select option...",
+  searchPlaceholder = "Search...",
+  emptyMessage = "No option found.",
+  disabled = false,
+  className,
+}: ComboboxProps) => {
+  const { control } = useFormContext();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={cn("flex flex-col", className)}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <FormControl>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  disabled={disabled}
+                  aria-expanded={open}
+                  className={cn(
+                    "w-full justify-between",
+                    !field.value && "text-muted-foreground"
+                  )}
+                >
+                  {field.value
+                    ? options.find((option) => option.value === field.value)?.label
+                    : placeholder}
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </FormControl>
+            </PopoverTrigger>
+            <PopoverContent className="w-full p-0">
+              <Command>
+                <CommandInput placeholder={searchPlaceholder} />
+                <CommandEmpty>{emptyMessage}</CommandEmpty>
+                <CommandList>
+                  <CommandGroup>
+                    {options.map((option) => (
+                      <CommandItem
+                        key={option.value}
+                        value={option.value}
+                        onSelect={(currentValue) => {
+                          field.onChange(currentValue === field.value ? "" : currentValue);
+                          setOpen(false);
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            field.value === option.value ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                        {option.label}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/apps/ship-stock/src/features/orders/api/selectOrderById.ts
+++ b/apps/ship-stock/src/features/orders/api/selectOrderById.ts
@@ -1,0 +1,111 @@
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import { supabase } from "../../../lib/supabase";
+
+export interface OrderWithDetails {
+  id: number;
+  order_type: string;
+  order_date: string;
+  carriage: number;
+  from_company_id: number | null;
+  to_company_id: number | null;
+  from_billing_address_id: number | null;
+  from_shipping_address_id: number | null;
+  to_billing_address_id: number | null;
+  to_shipping_address_id: number | null;
+  from_contact_id: number | null;
+  to_contact_id: number | null;
+  currency: string | null;
+  company_id: number | null;
+  reason_for_export: string | null;
+  mode_of_transport: string | null;
+  incoterms: string | null;
+  unit_of_measurement: string | null;
+  shipment_number: string | null;
+  airwaybill: string | null;
+  delivery_dates: string | null;
+  payment_status: string | null;
+  order_form_values: any | null;
+  reference_number: string | null;
+  order_item_changes: OrderItemChangeWithDetails[];
+}
+
+export interface OrderItemChangeWithDetails {
+  order_id: number;
+  item_change_id: number;
+  price: number | null;
+  tax: number | null;
+  lot_number: string | null;
+  package_item_change_id: number | null;
+  item_changes: {
+    id: number;
+    item_id: number;
+    quantity_change: number;
+    address_id: number | null;
+    items: {
+      id: number;
+      name: string;
+      price: number | null;
+      type: string;
+      hs_code: string | null;
+      sku: string | null;
+      country_of_origin: string | null;
+      height: number | null;
+      width: number | null;
+      depth: number | null;
+      weight: number | null;
+      company_id: number | null;
+    };
+    addresses: {
+      id: number;
+      name: string | null;
+      line_1: string | null;
+      line_2: string | null;
+      city: string | null;
+      region: string | null;
+      code: string | null;
+      country: string | null;
+      is_active: boolean | null;
+      holds_stock: boolean | null;
+      company_id: number | null;
+      is_default_shipping: boolean | null;
+      is_default_billing: boolean | null;
+    } | null;
+  };
+}
+
+export const selectOrderById = async (id: string): Promise<OrderWithDetails> => {
+  const { data, error } = await supabase
+    .from("orders")
+    .select(`
+      *,
+      order_item_changes (
+        *,
+        item_changes (
+          *,
+          items (*),
+          addresses (*)
+        )
+      )
+    `)
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    throw error;
+  }
+  return data as OrderWithDetails;
+};
+
+export const selectOrderByIdQueryKey = (id: string) => ({
+  queryKey: ["select-order-by-id", id],
+});
+
+export const selectOrderByIdQueryOptions = (id: string) => {
+  return queryOptions({
+    ...selectOrderByIdQueryKey(id),
+    queryFn: () => selectOrderById(id),
+  });
+};
+
+export const useSelectOrderById = (id: string) =>
+  useSuspenseQuery(selectOrderByIdQueryOptions(id));

--- a/apps/ship-stock/src/features/orders/api/updateItemChange.ts
+++ b/apps/ship-stock/src/features/orders/api/updateItemChange.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "../../../lib/supabase";
+import { toast } from "sonner";
+import { selectOrderByIdQueryKey } from "./selectOrderById";
+
+export interface UpdateItemChangeData {
+  id: number;
+  quantity_change?: number;
+  address_id?: number | null;
+}
+
+export const updateItemChange = async (data: UpdateItemChangeData) => {
+  const { id, ...updateData } = data;
+  
+  const { error } = await supabase
+    .from("item_changes")
+    .update(updateData)
+    .eq("id", id);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const useUpdateItemChange = (orderId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateItemChange,
+    onError: (error) => {
+      console.error(error);
+      toast.error("Failed to update item change");
+    },
+    onSuccess: () => {
+      toast.success("Item change updated successfully");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(selectOrderByIdQueryKey(orderId));
+    },
+  });
+};

--- a/apps/ship-stock/src/features/orders/api/updateOrderItemChange.ts
+++ b/apps/ship-stock/src/features/orders/api/updateOrderItemChange.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "../../../lib/supabase";
+import { toast } from "sonner";
+import { selectOrderByIdQueryKey } from "./selectOrderById";
+
+export interface UpdateOrderItemChangeData {
+  order_id: number;
+  item_change_id: number;
+  price?: number | null;
+  tax?: number | null;
+  lot_number?: string | null;
+  package_item_change_id?: number | null;
+}
+
+export const updateOrderItemChange = async (data: UpdateOrderItemChangeData) => {
+  const { order_id, item_change_id, ...updateData } = data;
+  
+  const { error } = await supabase
+    .from("order_item_changes")
+    .update(updateData)
+    .eq("order_id", order_id)
+    .eq("item_change_id", item_change_id);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const useUpdateOrderItemChange = (orderId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateOrderItemChange,
+    onError: (error) => {
+      console.error(error);
+      toast.error("Failed to update order item");
+    },
+    onSuccess: () => {
+      toast.success("Order item updated successfully");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(selectOrderByIdQueryKey(orderId));
+    },
+  });
+};

--- a/apps/ship-stock/src/features/orders/components/EditableItemChange.tsx
+++ b/apps/ship-stock/src/features/orders/components/EditableItemChange.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Card, CardContent, CardHeader, CardTitle } from "@thetis/ui/card";
+import { Button } from "@thetis/ui/button";
+import { Input } from "@/components/Input";
+import { Combobox, ComboboxOption } from "@/components/Combobox";
+import { OrderItemChangeWithDetails } from "../api/selectOrderById";
+import { useUpdateItemChange } from "../api/updateItemChange";
+
+const itemChangeSchema = z.object({
+  quantity_change: z.coerce.number().optional(),
+  address_id: z.coerce.number().nullable().optional(),
+});
+
+type ItemChangeFormData = z.infer<typeof itemChangeSchema>;
+
+interface EditableItemChangeProps {
+  orderItemChange: OrderItemChangeWithDetails;
+  orderId: string;
+  addressOptions: ComboboxOption[];
+}
+
+export const EditableItemChange = ({
+  orderItemChange,
+  orderId,
+  addressOptions,
+}: EditableItemChangeProps) => {
+  const updateItemChange = useUpdateItemChange(orderId);
+  const itemChange = orderItemChange.item_changes;
+
+  const form = useForm<ItemChangeFormData>({
+    resolver: zodResolver(itemChangeSchema),
+    defaultValues: {
+      quantity_change: itemChange.quantity_change,
+      address_id: itemChange.address_id,
+    },
+  });
+
+  const onSubmit = async (data: ItemChangeFormData) => {
+    await updateItemChange.mutateAsync({
+      id: itemChange.id,
+      ...data,
+    });
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle className="text-sm">
+          Item Change: {itemChange.items.name}
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Current Location: {itemChange.addresses?.name || "No address"}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                name="quantity_change"
+                label="Quantity Change"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+              />
+              <Combobox
+                name="address_id"
+                label="Address"
+                options={addressOptions}
+                placeholder="Select address..."
+                searchPlaceholder="Search addresses..."
+                emptyMessage="No addresses found."
+              />
+            </div>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={updateItemChange.isPending}
+            >
+              {updateItemChange.isPending ? "Updating..." : "Update"}
+            </Button>
+          </form>
+        </FormProvider>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/ship-stock/src/features/orders/components/EditableOrderItemChange.tsx
+++ b/apps/ship-stock/src/features/orders/components/EditableOrderItemChange.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Card, CardContent, CardHeader, CardTitle } from "@thetis/ui/card";
+import { Button } from "@thetis/ui/button";
+import { Input } from "@/components/Input";
+import { Combobox, ComboboxOption } from "@/components/Combobox";
+import { OrderItemChangeWithDetails } from "../api/selectOrderById";
+import { useUpdateOrderItemChange } from "../api/updateOrderItemChange";
+
+const orderItemChangeSchema = z.object({
+  price: z.coerce.number().min(0).nullable().optional(),
+  tax: z.coerce.number().min(0).nullable().optional(),
+  lot_number: z.string().nullable().optional(),
+  package_item_change_id: z.coerce.number().nullable().optional(),
+});
+
+type OrderItemChangeFormData = z.infer<typeof orderItemChangeSchema>;
+
+interface EditableOrderItemChangeProps {
+  orderItemChange: OrderItemChangeWithDetails;
+  orderId: string;
+  itemOptions: ComboboxOption[];
+}
+
+export const EditableOrderItemChange = ({
+  orderItemChange,
+  orderId,
+  itemOptions,
+}: EditableOrderItemChangeProps) => {
+  const updateOrderItemChange = useUpdateOrderItemChange(orderId);
+
+  const form = useForm<OrderItemChangeFormData>({
+    resolver: zodResolver(orderItemChangeSchema),
+    defaultValues: {
+      price: orderItemChange.price,
+      tax: orderItemChange.tax,
+      lot_number: orderItemChange.lot_number,
+      package_item_change_id: orderItemChange.package_item_change_id,
+    },
+  });
+
+  const onSubmit = async (data: OrderItemChangeFormData) => {
+    await updateOrderItemChange.mutateAsync({
+      order_id: orderItemChange.order_id,
+      item_change_id: orderItemChange.item_change_id,
+      ...data,
+    });
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle className="text-sm">
+          Order Item: {orderItemChange.item_changes.items.name}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                name="price"
+                label="Price"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+              />
+              <Input
+                name="tax"
+                label="Tax"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                name="lot_number"
+                label="Lot Number"
+                placeholder="Enter lot number"
+              />
+              <Combobox
+                name="package_item_change_id"
+                label="Package Item"
+                options={itemOptions}
+                placeholder="Select package item..."
+                searchPlaceholder="Search packages..."
+                emptyMessage="No packages found."
+              />
+            </div>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={updateOrderItemChange.isPending}
+            >
+              {updateOrderItemChange.isPending ? "Updating..." : "Update"}
+            </Button>
+          </form>
+        </FormProvider>
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/ship-stock/src/routes/home/orders/$orderId.details.tsx
+++ b/apps/ship-stock/src/routes/home/orders/$orderId.details.tsx
@@ -1,0 +1,138 @@
+import { createFileRoute } from '@tanstack/react-router'
+import React from 'react'
+import { useSelectOrderById } from '@/features/orders/api/selectOrderById'
+import { useSelectAddresses } from '@/features/stockpiles/api/selectAddresses'
+import { useSelectItems } from '@/features/items/api/selectItems'
+import { EditableOrderItemChange } from '@/features/orders/components/EditableOrderItemChange'
+import { EditableItemChange } from '@/features/orders/components/EditableItemChange'
+import { ComboboxOption } from '@/components/Combobox'
+import { Card, CardContent, CardHeader, CardTitle } from '@thetis/ui/card'
+import { Badge } from '@thetis/ui/badge'
+import { Separator } from '@thetis/ui/separator'
+
+export const Route = createFileRoute('/home/orders/$orderId/details')({
+  component: RouteComponent,
+})
+
+function RouteComponent() {
+  const { orderId } = Route.useParams()
+  const { data: order } = useSelectOrderById(orderId)
+  const { data: addresses } = useSelectAddresses()
+  const { data: items } = useSelectItems()
+
+  // Convert addresses to combobox options
+  const addressOptions: ComboboxOption[] = React.useMemo(() => 
+    addresses?.map(address => ({
+      value: address.id.toString(),
+      label: address.name || `${address.line_1}, ${address.city}` || 'Unnamed Address'
+    })) || [], [addresses]
+  )
+
+  // Convert items to combobox options (for package items)
+  const itemOptions: ComboboxOption[] = React.useMemo(() => 
+    items?.map(item => ({
+      value: item.id.toString(),
+      label: item.name
+    })) || [], [items]
+  )
+
+  if (!order) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Order Header */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Order #{order.id}</span>
+            <Badge variant="outline">{order.order_type}</Badge>
+          </CardTitle>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+            <div>
+              <p className="font-medium">Order Date</p>
+              <p className="text-muted-foreground">{new Date(order.order_date).toLocaleDateString()}</p>
+            </div>
+            <div>
+              <p className="font-medium">Currency</p>
+              <p className="text-muted-foreground">{order.currency || 'N/A'}</p>
+            </div>
+            <div>
+              <p className="font-medium">Carriage</p>
+              <p className="text-muted-foreground">{order.carriage}</p>
+            </div>
+            <div>
+              <p className="font-medium">Payment Status</p>
+              <p className="text-muted-foreground">{order.payment_status || 'N/A'}</p>
+            </div>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* Order Items */}
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">Order Items</h2>
+        {order.order_item_changes.map((orderItemChange, index) => (
+          <div key={`${orderItemChange.order_id}-${orderItemChange.item_change_id}`} className="space-y-4">
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-semibold">Item #{index + 1}</h3>
+              <Badge variant="secondary">{orderItemChange.item_changes.items.type}</Badge>
+            </div>
+            
+            {/* Item Information */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Item Information</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <p className="font-medium">Name</p>
+                    <p className="text-muted-foreground">{orderItemChange.item_changes.items.name}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">SKU</p>
+                    <p className="text-muted-foreground">{orderItemChange.item_changes.items.sku || 'N/A'}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Base Price</p>
+                    <p className="text-muted-foreground">{orderItemChange.item_changes.items.price || 'N/A'}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">HS Code</p>
+                    <p className="text-muted-foreground">{orderItemChange.item_changes.items.hs_code || 'N/A'}</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <div className="grid md:grid-cols-2 gap-6">
+              {/* Order Item Change */}
+              <div>
+                <h4 className="text-md font-medium mb-3">Order Item Details</h4>
+                <EditableOrderItemChange
+                  orderItemChange={orderItemChange}
+                  orderId={orderId}
+                  itemOptions={itemOptions}
+                />
+              </div>
+
+              {/* Item Change */}
+              <div>
+                <h4 className="text-md font-medium mb-3">Item Change Details</h4>
+                <EditableItemChange
+                  orderItemChange={orderItemChange}
+                  orderId={orderId}
+                  addressOptions={addressOptions}
+                />
+              </div>
+            </div>
+
+            {index < order.order_item_changes.length - 1 && <Separator className="my-6" />}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds an order details page to view and granularly edit order items and their associated changes.

This PR implements a "simplified database editor" for order details, allowing users to update specific fields of `order_item_changes` and `item_changes` individually. It groups related item information, item changes, and order item changes, providing dedicated forms for each editable section and utilizing new reusable comboboxes for selecting addresses and items.

---
<a href="https://cursor.com/background-agent?bcId=bc-e65192c2-13c9-477b-8baa-15fac1a5fec8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e65192c2-13c9-477b-8baa-15fac1a5fec8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

