### PR TITLE
Update order folder imports

### DIFF
--- a/apps/ship-stock/src/features/orders/components/DeliveryStatusSelect.tsx
+++ b/apps/ship-stock/src/features/orders/components/DeliveryStatusSelect.tsx
@@ -5,7 +5,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@thetis/ui/select";
-import { useUpdateOrder } from "@/features/orders/api/updateOrder";
+import { useUpdateOrder } from "../api/updateOrder";
 import { cn } from "@/lib/utils";
 import {
     AlertTriangle,

--- a/apps/ship-stock/src/features/orders/components/OrderForm.tsx
+++ b/apps/ship-stock/src/features/orders/components/OrderForm.tsx
@@ -1,11 +1,11 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@thetis/ui/tabs";
 import BuyForm from "../features/order-forms/features/buy-form/BuyForm";
 import { Banknote, Info, ShoppingCart, Truck } from "lucide-react";
-import ShipmentForm from "../features/order-forms/features/shipment-form/ShipmentForm";
+import { MultiOrderForm } from "../features/multi-order-form/MultiOrderForm";
 import { Alert, AlertDescription, AlertTitle } from "@thetis/ui/alert";
 import SellForm from "../features/order-forms/features/sell-form/components/SellForm";
 import type { OrderTab } from "../../../routes/home/orders";
-import SaleForm from "../features/order-forms/features/sale-form/SaleForm";
+
 import { OrderSettings } from "../features/order-forms/features/order-settings/components/OrderSettings";
 
 export const OrderForm: React.FC = ({
@@ -67,7 +67,7 @@ export const OrderForm: React.FC = ({
             where you keep stock.
           </AlertDescription>
         </Alert>
-        <ShipmentForm />
+        <MultiOrderForm defaultOrderType="shipment" />
       </TabsContent>
     </Tabs>
   );

--- a/apps/ship-stock/src/features/orders/components/PaymentStatusSelect.tsx
+++ b/apps/ship-stock/src/features/orders/components/PaymentStatusSelect.tsx
@@ -5,7 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@thetis/ui/select";
-import { useUpdateOrder } from "@/features/orders/api/updateOrder";
+import { useUpdateOrder } from "../api/updateOrder";
 import { cn } from "@/lib/utils";
 
 interface PaymentStatusSelectProps {

--- a/apps/ship-stock/src/features/orders/features/order-documents/components/Contact.tsx
+++ b/apps/ship-stock/src/features/orders/features/order-documents/components/Contact.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { OrderView } from "@/features/orders/types";
+import { OrderView } from "../../../types";
 const Contact = ({ contact }: { contact: OrderView["to_contact"] }) => {
   return (
     <div>

--- a/apps/ship-stock/src/features/orders/features/order-forms/hooks/useOrderItems.tsx
+++ b/apps/ship-stock/src/features/orders/features/order-forms/hooks/useOrderItems.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from "react-hook-form";
-import { PricedOrderItem } from "../../../features/multi-order-form/schema";
+import { PricedOrderItem } from "../../multi-order-form/schema";
 import { useSelectItemsView } from "@/features/items/api/selectItemsView";
 
 type OrderItemWithTotal = PricedOrderItem & {

--- a/apps/ship-stock/src/features/orders/features/order-history/components/FinancialTransactions.tsx
+++ b/apps/ship-stock/src/features/orders/features/order-history/components/FinancialTransactions.tsx
@@ -7,7 +7,7 @@ import {
     TableHeader,
     TableRow,
 } from "@thetis/ui/table";
-import type { OrderView } from "@/features/orders/types";
+import type { OrderView } from "../../../types";
 import type { Currency as CurrencyType } from '../../../../../constants/currencies';
 import NumberFlow from '@number-flow/react';
 /**

--- a/apps/ship-stock/src/features/orders/features/order-history/components/StockMovements.tsx
+++ b/apps/ship-stock/src/features/orders/features/order-history/components/StockMovements.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useMemo } from "react";
-import type { OrderView } from "@/features/orders/types";
+import type { OrderView } from "../../../types";
 import {
   Table,
   TableBody,


### PR DESCRIPTION
Update imports across the `orders` feature to reflect folder reorganization and refactor `OrderForm` component.

The `OrderForm` component was updated to use `MultiOrderForm` instead of the non-existent `ShipmentForm`, and an unused `SaleForm` import was removed, aligning with the new component structure after the folder reorganization.

---
<a href="https://cursor.com/background-agent?bcId=bc-4244e710-1783-4a1e-8205-d4d6b782fb81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4244e710-1783-4a1e-8205-d4d6b782fb81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

